### PR TITLE
Add Mark and Unmark Present commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Marks a member as present for the current session.
+ * Command usage: present INDEX
+ */
+public class MarkCommand extends Command {
+
+    public static final String COMMAND_WORD = "present";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Mark the member at the given index as present.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SUCCESS = "Member '%s' marked present!";
+    public static final String MESSAGE_INVALID_INDEX = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+
+    private final Index targetIndex;
+
+    public MarkCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_INDEX);
+        }
+
+        Person personToMark = lastShownList.get(targetIndex.getZeroBased());
+
+        // Create a new Person with isPresent = true (idempotent; always succeeds)
+        Person marked = personToMark.withPresence(true);
+
+        model.setPerson(personToMark, marked);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, marked.getName().fullName));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit
+                || (other instanceof MarkCommand
+                && targetIndex.equals(((MarkCommand) other).targetIndex));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Unmarks a member as present for the current session.
+ * Command usage: unmark INDEX
+ */
+public class UnmarkCommand extends Command {
+
+    public static final String COMMAND_WORD = "unmark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unmark the member at the given index as present.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 2";
+
+    public static final String MESSAGE_SUCCESS = "Member '%s' unmarked!";
+    public static final String MESSAGE_INVALID_INDEX = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+
+    private final Index targetIndex;
+
+    public UnmarkCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_INDEX);
+        }
+
+        Person personToUnmark = lastShownList.get(targetIndex.getZeroBased());
+
+        // Create a new Person with isPresent = false
+        Person unmarked = personToUnmark.withPresence(false);
+
+        model.setPerson(personToUnmark, unmarked);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, unmarked.getName().fullName));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof UnmarkCommand
+                && targetIndex.equals(((UnmarkCommand) other).targetIndex));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,10 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.MarkCommandParser;
+import seedu.address.logic.parser.UnmarkCommandParser;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.UnmarkCommand;
 
 /**
  * Parses user input.
@@ -76,6 +80,12 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+            case MarkCommand.COMMAND_WORD:
+                return new MarkCommandParser().parse(arguments);
+
+            case UnmarkCommand.COMMAND_WORD:
+                return new UnmarkCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.ParserUtil.parseIndex;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new PresentCommand object
+ * Accepts leading/trailing spaces; requires a whole-number index.
+ */
+public class MarkCommandParser implements Parser<MarkCommand> {
+
+    @Override
+    public MarkCommand parse(String args) throws ParseException {
+        String trimmed = args.trim();
+        if (trimmed.isEmpty()) {
+            // Let parseIndex throw the standard index parse error for non-positive/empty inputs
+        }
+        Index index = parseIndex(trimmed);
+        return new MarkCommand(index);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.ParserUtil.parseIndex;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnmarkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UnmarkCommand object
+ * Accepts leading/trailing spaces; requires a whole-number index.
+ */
+public class UnmarkCommandParser implements Parser<UnmarkCommand> {
+
+    @Override
+    public UnmarkCommand parse(String args) throws ParseException {
+        String trimmed = args.trim();
+        Index index = parseIndex(trimmed);
+        return new UnmarkCommand(index);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,11 +24,13 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final boolean isPresent;
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, boolean isPresent) {
+        this.isPresent = isPresent;
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
@@ -74,6 +76,10 @@ public class Person {
                 && otherPerson.getName().equals(getName());
     }
 
+    public boolean isPresent() {
+        return isPresent;
+    }
+
     /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
@@ -103,6 +109,10 @@ public class Person {
         return Objects.hash(name, phone, email, address, tags);
     }
 
+    public Person withPresence(boolean isPresent) {
+        return new Person(name, phone, email, address, tags, isPresent);
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
@@ -111,6 +121,7 @@ public class Person {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("isPresent", isPresent)
                 .toString();
     }
 


### PR DESCRIPTION
Add `PresentCommand` and `UnmarkCommand` to allow users to mark or unmark members as present for the current session using their displayed index.

This improves ClubTrack’s functionality for attendance management, making it faster for Exco members to record participation directly from the CLI.