### PR TITLE
Fix: Preserve points when marking/unmarking attendance

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -65,7 +65,8 @@ public class MarkCommand extends Command {
             personToMark.getFaculty(),
             personToMark.getAddress(),
             personToMark.getTags(),
-            true
+            true,
+            personToMark.getPoints()
         );
 
         model.setPerson(personToMark, markedPerson);

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -65,7 +65,8 @@ public class UnmarkCommand extends Command {
             personToUnmark.getFaculty(),
             personToUnmark.getAddress(),
             personToUnmark.getTags(),
-            false
+            false,
+            personToUnmark.getPoints()
         );
 
         model.setPerson(personToUnmark, unmarkedPerson);


### PR DESCRIPTION
### Fix points reset when marking/unmarking attendance
Fixes critical data loss bug where points are reset to zero when attendance status changes.

**Changes:**
- Use 9-parameter Person constructor in MarkCommand
- Use 9-parameter Person constructor in UnmarkCommand  
- Preserves existing points when attendance status changes

**Impact:** Prevents data loss and maintains points system integrity

Resolves #72 