### PR TITLE
Fix: Add integer overflow protection in AddPointsCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
@@ -62,7 +62,17 @@ public class AddPointsCommand extends Command {
         Person personToUpdate = lastShownList.get(targetIndex.getZeroBased());
         Set<Tag> preservedTags = personToUpdate.getTags();
 
-        Points newPoints = new Points(personToUpdate.getPoints().getValue() + pointsToAdd);
+        int currentPoints = personToUpdate.getPoints().getValue();
+        if (pointsToAdd > 0 && currentPoints > Integer.MAX_VALUE - pointsToAdd) {
+            throw new CommandException("Adding " + pointsToAdd + " points would cause overflow. "
+                + "Current points: " + currentPoints + ", Maximum allowed: " + Integer.MAX_VALUE);
+        }
+        if (pointsToAdd < 0 && currentPoints < Integer.MIN_VALUE - pointsToAdd) {
+            throw new CommandException("Subtracting points would cause underflow. "
+                + "Current points: " + currentPoints + ", Minimum allowed: " + Integer.MIN_VALUE);
+        }
+
+        Points newPoints = new Points(currentPoints + pointsToAdd);
 
         Person updatedPerson = new Person(
             personToUpdate.getName(),


### PR DESCRIPTION
### Fix integer overflow in AddPointsCommand
Prevents integer overflow that can cause negative or unexpected point values.

**Changes:**
- Add overflow detection before point addition
- Throw descriptive CommandException on overflow
- Include underflow protection for negative additions

**Impact:** Prevents system instability from integer overflow

Resolves #73 