### PR TITLE
Fix: Add missing equals() and hashCode() for points commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPointsCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -81,5 +82,25 @@ public class AddPointsCommand extends Command {
             personToUpdate.getName(),
             pointsToAdd,
             newPoints.getValue()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AddPointsCommand)) {
+            return false;
+        }
+
+        AddPointsCommand otherCommand = (AddPointsCommand) other;
+        return targetIndex.equals(otherCommand.targetIndex)
+            && pointsToAdd == otherCommand.pointsToAdd;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetIndex, pointsToAdd);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/MinusPointsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MinusPointsCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -83,5 +84,25 @@ public class MinusPointsCommand extends Command {
             personToUpdate.getName(),
             pointsToSubtract,
             newPoints.getValue()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof MinusPointsCommand)) {
+            return false;
+        }
+
+        MinusPointsCommand otherCommand = (MinusPointsCommand) other;
+        return targetIndex.equals(otherCommand.targetIndex)
+            && pointsToSubtract == otherCommand.pointsToSubtract;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetIndex, pointsToSubtract);
     }
 }


### PR DESCRIPTION
### Implement equals() and hashCode() for points commands
Adds proper equality comparison methods to points commands to ensure consistent behavior in collections and testing.

**Changes:**
- Add equals() method to AddPointsCommand with proper field comparison
- Add hashCode() method to AddPointsCommand using Objects.hash()
- Add equals() method to MinusPointsCommand with proper field comparison
- Add hashCode() method to MinusPointsCommand using Objects.hash()
- Add required import for java.util.Objects

**Impact:** Enables consistent behavior in collections, testing frameworks, and command comparison operations

Resolves #74 