### PR TITLE
Fix: Include points field in Person.toString()

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -167,6 +167,7 @@ public class Person {
                 .add("address", address)
                 .add("tags", tags)
                 .add("isPresent", isPresent)
+                .add("points", points)
                 .toString();
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -92,10 +92,17 @@ public class PersonTest {
 
     @Test
     public void toStringMethod() {
-        String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", year of study=" + ALICE.getYearOfStudy() + ", faculty="
-                + ALICE.getFaculty() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
-                + ", isPresent=" + ALICE.isPresent() + "}";
+        String expected = Person.class.getCanonicalName()
+            + "{name=" + ALICE.getName()
+            + ", phone=" + ALICE.getPhone()
+            + ", email=" + ALICE.getEmail()
+            + ", year of study=" + ALICE.getYearOfStudy()
+            + ", faculty=" + ALICE.getFaculty()
+            + ", address=" + ALICE.getAddress()
+            + ", tags=" + ALICE.getTags()
+            + ", isPresent=" + ALICE.isPresent()
+            + ", points=" + ALICE.getPoints()
+            + "}";
         assertEquals(expected, ALICE.toString());
     }
 }


### PR DESCRIPTION
### Include points field in Person.toString() output
Adds points field to Person string representation to improve debugging capabilities and data visibility.

**Changes:**
- Add points field to ToStringBuilder in Person.toString() method
- Maintains existing field order and formatting
- Preserves compatibility with current toString structure

**Impact:** Improves debugging experience and provides complete data representation for Person objects

Resolves #75 